### PR TITLE
feat: Change website name to Wall Street Bets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Stock Trading Game
+# Wall Street Bets
 
-A web-based stock trading game inspired by the FIFA Companion App, featuring a leaderboard, tiered rankings, strategy testing via a chat terminal, and user profiles with tokenized investment options.
+A web-based trading platform inspired by the Wall Street Bets community, featuring a leaderboard, tiered rankings, strategy testing via a chat terminal, and user profiles with tokenized investment options.
 
 ## Features
 
@@ -37,7 +37,7 @@ A web-based stock trading game inspired by the FIFA Companion App, featuring a l
 1. **Clone and install dependencies:**
    ```bash
    git clone <repo-url>
-   cd stock-trading-game
+   cd wall-street-bets
    npm install
    ```
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,8 @@ import Navbar from '@/components/Navbar'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  title: 'Stock Trading Game',
-  description: 'Compete, Trade, Win! A web-based stock trading game with leaderboards and strategy testing.',
+  title: 'Wall Street Bets',
+  description: 'Compete, Trade, Win! A web-based trading platform inspired by the Wall Street Bets community with leaderboards and strategy testing.',
 }
 
 export default function RootLayout({

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -31,7 +31,7 @@ export default function Navbar() {
           <div className="flex items-center">
             <Link href="/" className="flex-shrink-0 flex items-center">
               <h1 className="text-xl font-bold text-blue-600 dark:text-blue-400">
-                TradingGame
+                Wall Street Bets
               </h1>
             </Link>
           </div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stock-trading-game",
+  "name": "wall-street-bets",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
-# Stock Trading Game
+# Wall Street Bets
 
-A web-based stock trading game inspired by the FIFA Companion App, featuring a leaderboard, tiered rankings, strategy testing via a chat terminal, and user profiles with tokenized investment options. Users can filter by technologies, companies, or assets, view top strategies, and simulate trades using technical indicators like Keltner Channels and Bollinger Bands.
+A web-based trading platform inspired by the Wall Street Bets community, featuring a leaderboard, tiered rankings, strategy testing via a chat terminal, and user profiles with tokenized investment options. Users can filter by technologies, companies, or assets, view top strategies, and simulate trades using technical indicators like Keltner Channels and Bollinger Bands.
 
 ## Features
 


### PR DESCRIPTION
## Website Rebranding: Stock Trading Game → Wall Street Bets

This pull request implements a comprehensive rebranding of the application from "Stock Trading Game" to "Wall Street Bets", completed with assistance from Comet Assistant.

### Changes Made:
- **Package name**: Updated from `stock-trading-game` to `wall-street-bets`
- **Documentation**: Updated README.md and readme.markdown titles and descriptions
- **Application metadata**: Updated title and description in layout.tsx
- **UI branding**: Updated navbar from "TradingGame" to "Wall Street Bets"
- **Directory references**: Updated installation commands to reflect new naming

### Context:
This rebranding aligns the project with the Wall Street Bets community theme while maintaining all existing functionality and features.

CC: @claude